### PR TITLE
Fix pain points in GPT-2 tutorial

### DIFF
--- a/finetuning-English-GPT2-any-language-Portuguese-HuggingFace-fastaiv2.ipynb
+++ b/finetuning-English-GPT2-any-language-Portuguese-HuggingFace-fastaiv2.ipynb
@@ -578,8 +578,9 @@
   {
    "cell_type": "code",
    "outputs": [],
+   "metadata": {},
    "source": [
-    "! pip install torch fastai2 fastcore==0.1.38",
+    "! pip install torch fastai2 fastcore==0.1.38"
    ]
   },
   {

--- a/finetuning-English-GPT2-any-language-Portuguese-HuggingFace-fastaiv2.ipynb
+++ b/finetuning-English-GPT2-any-language-Portuguese-HuggingFace-fastaiv2.ipynb
@@ -577,6 +577,13 @@
   },
   {
    "cell_type": "code",
+   "outputs": [],
+   "source": [
+    "! pip install torch fastai2 fastcore==0.1.38",
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "nbpresent": {

--- a/nlputils_fastai2.py
+++ b/nlputils_fastai2.py
@@ -25,7 +25,7 @@ def get_wiki(path,lang):
     os.chdir(path)
     
     # Get wikiextractor
-    if not (path/'wikiextractor').exists(): os.system('git clone https://github.com/attardi/wikiextractor.git')
+    if not (path/'wikiextractor').exists(): os.system('git clone https://github.com/attardi/wikiextractor.git && cd wikiextractor && git checkout 16186e290d9eb0eb3a3784c6c0635a9ed7e855c3')
 
     # Extraction
     print("extracting...")


### PR DESCRIPTION
- WikiExtractor repo recently changed things around - simpler to use previous script by checkout old commit hash

- Added pip install line to one of the GPT-2 tutorial notebooks (I think it's your main one).  Recently ```pip install fastai2``` alone installs fastcore 1.x, leaving a confusing error; adding a specific ```pip install fastcore==0.1.38``` resolves this

![Screen Shot 2020-09-07 at 12 01 16 AM](https://user-images.githubusercontent.com/643918/92349552-75cea080-f0a4-11ea-9261-8a5d4a4536d8.png)
